### PR TITLE
Add InjectClient and InjectDecoder to VolumeMutator

### DIFF
--- a/pkg/kube/webhooks/volume_mutator.go
+++ b/pkg/kube/webhooks/volume_mutator.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 // Device is the device which the volume is refered to
@@ -140,4 +141,24 @@ func (m *VolumeMutator) Handle(ctx context.Context, req types.Request) types.Res
 	}
 
 	return admission.PatchResponse(pod, podCopy)
+}
+
+// VolumeMutator implements inject.Client.
+// A client will be automatically injected.
+var _ inject.Client = &VolumeMutator{}
+
+// InjectClient injects the client.
+func (m *VolumeMutator) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+// VolumeMutator implements inject.Decoder.
+// A decoder will be automatically injected.
+var _ inject.Decoder = &VolumeMutator{}
+
+// InjectDecoder injects the decoder.
+func (m *VolumeMutator) InjectDecoder(d types.Decoder) error {
+	m.decoder = d
+	return nil
 }


### PR DESCRIPTION
Make VolumeMutator satisfy inject.Client and inject.Decoder,
used by the ControllerManager to inject decoder into webhook handlers.

Seems to be used here: https://github.com/kubernetes-sigs/controller-runtime/blob/58a08d8098290a173ef143bd28820f4308916948/pkg/webhook/admission/inject.go#L26 , which makes in turn to be the decoder empty, which is implied to be there in the other parts of the code.

Stacktrace:
```

2019/04/24 14:24:18 http2: panic serving 10.32.0.1:49572: runtime error: invalid memory address or nil pointer dereference
goroutine 319 [running]:
net/http.(*http2serverConn).runHandler.func1(0xc00000e058, 0xc0004d3faf, 0xc000182540)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5870 +0x17c
panic(0x12a57e0, 0x213ab70)
        /var/vcap/packages/golang/src/runtime/panic.go:513 +0x1b9
github.com/SUSE/eirini-extensions/pkg/kube/webhooks.GetPodFunc(0x0, 0x0, 0xc00014a2c0, 0xc0004b4000, 0xc0004d3a20, 0x40dd98)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/pkg/kube/webhooks/volume_webhook.go:26 +0x3c
github.com/SUSE/eirini-extensions/pkg/kube/webhooks.(*VolumeMutator).Handle(0xc0000a43c0, 0x15b5480, 0xc000042170, 0xc00014a2c0, 0x7, 0x11b22f5, 0xf, 0x15993e0)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/pkg/kube/webhooks/volume_mutator.go:128 +0x4a
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).handleMutating(0xc00050a680, 0x15b5480, 0xc000042170, 0xc00014a2c0, 0x30, 0x0, 0xc0000be101, 0xc0003ba540)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:133 +0xeb
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(0xc00050a680, 0x15b5480, 0xc000042170, 0xc00014a2c0, 0x0, 0x159faa0, 0xc00013f8f0, 0x159faa0)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:120 +0x187
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc00050a680, 0x15b3d80, 0xc00000e058, 0xc0002eca00)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/http.go:93 +0x72c
net/http.(*ServeMux).ServeHTTP(0xc00050e5d0, 0x15b3d80, 0xc00000e058, 0xc0002eca00)
        /var/vcap/packages/golang/src/net/http/server.go:2361 +0x127
net/http.serverHandler.ServeHTTP(0xc0001609c0, 0x15b3d80, 0xc00000e058, 0xc0002eca00)
        /var/vcap/packages/golang/src/net/http/server.go:2741 +0xab
net/http.initNPNRequest.ServeHTTP(0xc00012ca80, 0xc0001609c0, 0x15b3d80, 0xc00000e058, 0xc0002eca00)
        /var/vcap/packages/golang/src/net/http/server.go:3291 +0x8d
net/http.Handler.ServeHTTP-fm(0x15b3d80, 0xc00000e058, 0xc0002eca00)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5592 +0x4d
net/http.(*http2serverConn).runHandler(0xc000182540, 0xc00000e058, 0xc0002eca00, 0xc00035e0e0)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5877 +0x89
created by net/http.(*http2serverConn).processHeaders
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5611 +0x4d3
2019/04/24 14:25:49 http2: panic serving 10.32.0.1:49572: runtime error: invalid memory address or nil pointer dereference
goroutine 328 [running]:
net/http.(*http2serverConn).runHandler.func1(0xc000140008, 0xc0000e1faf, 0xc000182540)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5870 +0x17c
panic(0x12a57e0, 0x213ab70)
        /var/vcap/packages/golang/src/runtime/panic.go:513 +0x1b9
github.com/SUSE/eirini-extensions/pkg/kube/webhooks.GetPodFunc(0x0, 0x0, 0xc0003c6160, 0xc000196800, 0xc0000e1a20, 0x40dd98)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/pkg/kube/webhooks/volume_webhook.go:26 +0x3c
github.com/SUSE/eirini-extensions/pkg/kube/webhooks.(*VolumeMutator).Handle(0xc0000a43c0, 0x15b5480, 0xc000042170, 0xc0003c6160, 0x7, 0x11b22f5, 0xf, 0x15993e0)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/pkg/kube/webhooks/volume_mutator.go:128 +0x4a
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).handleMutating(0xc00050a680, 0x15b5480, 0xc000042170, 0xc0003c6160, 0x30, 0x0, 0xc0000be101, 0xc0003ba540)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:133 +0xeb
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(0xc00050a680, 0x15b5480, 0xc000042170, 0xc0003c6160, 0x0, 0x159faa0, 0xc0004ba090, 0x159faa0)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/webhook.go:120 +0x187
github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc00050a680, 0x15b3d80, 0xc000140008, 0xc0003cc200)
        /var/vcap/packages/eirini-extensions/src/github.com/SUSE/eirini-extensions/vendor/sigs.k8s.io/controller-runtime/pkg/webhook/admission/http.go:93 +0x72c
net/http.(*ServeMux).ServeHTTP(0xc00050e5d0, 0x15b3d80, 0xc000140008, 0xc0003cc200)
        /var/vcap/packages/golang/src/net/http/server.go:2361 +0x127
net/http.serverHandler.ServeHTTP(0xc0001609c0, 0x15b3d80, 0xc000140008, 0xc0003cc200)
        /var/vcap/packages/golang/src/net/http/server.go:2741 +0xab
net/http.initNPNRequest.ServeHTTP(0xc00012ca80, 0xc0001609c0, 0x15b3d80, 0xc000140008, 0xc0003cc200)
        /var/vcap/packages/golang/src/net/http/server.go:3291 +0x8d
net/http.Handler.ServeHTTP-fm(0x15b3d80, 0xc000140008, 0xc0003cc200)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5592 +0x4d
net/http.(*http2serverConn).runHandler(0xc000182540, 0xc000140008, 0xc0003cc200, 0xc0004d6080)
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5877 +0x89
created by net/http.(*http2serverConn).processHeaders
        /var/vcap/packages/golang/src/net/http/h2_bundle.go:5611 +0x4d3
```