### PR TITLE
Add operator webhook host to AlternativeNames

### DIFF
--- a/pkg/controllers/webhook_configuration.go
+++ b/pkg/controllers/webhook_configuration.go
@@ -98,9 +98,11 @@ func (f *WebhookConfig) setupCertificate(ctx context.Context) error {
 
 		// Generate CA
 		caRequest := credsgen.CertificateGenerationRequest{
-			CommonName: "SCF CA",
-			IsCA:       true,
+			CommonName:       "SCF CA",
+			IsCA:             true,
+			AlternativeNames: []string{f.config.WebhookServerHost},
 		}
+
 		caCert, err := f.generator.GenerateCertificate("webhook-server-ca", caRequest)
 		if err != nil {
 			return err


### PR DESCRIPTION
With this change we add the specified host to the generated certificate as an AlternativeName.